### PR TITLE
Add decoder and field for the buttons property

### DIFF
--- a/src/Mouse.elm
+++ b/src/Mouse.elm
@@ -4,6 +4,7 @@ module Mouse
         , Keys
         , Coordinates
         , Movement
+        , Button (..)
         , onDown
         , onMove
         , onUp


### PR DESCRIPTION
This exposes the [MouseEvent.buttons](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons) property in the `Mouse.Event` record.

The implementation of `buttonsDecoder` is a bit ugly, but I can't come up with a better way of doing it right now.

Also, I guess the same system could be used for decoding the MouseEvents.button property except that it doesn't use the same values for the buttons.